### PR TITLE
[Assignment 2.5- Unit Testcase] Added test cases for each models

### DIFF
--- a/src/ml_package/data_ingestion.py
+++ b/src/ml_package/data_ingestion.py
@@ -10,7 +10,10 @@ HOUSING_URL = DOWNLOAD_ROOT + "datasets/housing/housing.tgz"
 
 
 def fetch_housing_data(housing_url=HOUSING_URL, housing_path=HOUSING_PATH):
-    """Downloads and extracts the housing dataset."""
+    """
+    Downloads and extracts the housing dataset.
+    Fetching the data from the open source and storing in local directory
+    """
     os.makedirs(housing_path, exist_ok=True)
     tgz_path = os.path.join(housing_path, "housing.tgz")
     urllib.request.urlretrieve(housing_url, tgz_path)
@@ -21,4 +24,5 @@ def fetch_housing_data(housing_url=HOUSING_URL, housing_path=HOUSING_PATH):
 
 def load_housing_data(housing_path=HOUSING_PATH):
     csv_path = os.path.join(housing_path, "housing.csv")
+    # loading the data and returing
     return pd.read_csv(csv_path)

--- a/src/ml_package/data_preprocessing.py
+++ b/src/ml_package/data_preprocessing.py
@@ -5,14 +5,26 @@ from sklearn.model_selection import StratifiedShuffleSplit
 
 
 def stratified_split(housing):
-    """Performs stratified split based on income categories."""
+    """
+    Performs stratified split based on income categories.
+    Reason: Need the data with composed way.
+    Eg: For 100 data's we need to be equally distributed with train and test data
+    """
     housing["income_cat"] = pd.cut(
         housing["median_income"],
-        bins=[0.0, 1.5, 3.0, 4.5, 6.0, np.inf],
+        bins=[
+            0.0,
+            1.5,
+            3.0,
+            4.5,
+            6.0,
+            np.inf,
+        ],  # splitting the data in multiple bins [like 0.0 to 1.5 ]
         labels=[1, 2, 3, 4, 5],
     )
 
     split = StratifiedShuffleSplit(n_splits=1, test_size=0.2, random_state=42)
+    # splitted the equally distributed data based on income category
     for train_index, test_index in split.split(housing, housing["income_cat"]):
         strat_train_set = housing.loc[train_index]
         strat_test_set = housing.loc[test_index]
@@ -26,12 +38,18 @@ def stratified_split(housing):
 def preprocess_data(housing):
     """Handles missing values and feature engineering."""
     imputer = SimpleImputer(strategy="median")
-    housing_num = housing.drop("ocean_proximity", axis=1)
+    housing_num = housing.drop(
+        "ocean_proximity", axis=1
+    )  # dropping this column since it require only integer
 
+    # responsible for calculating the median of the columns which have missing values
     imputer.fit(housing_num)
+
+    # Filling those missing with median values
     X = imputer.transform(housing_num)
 
     housing_tr = pd.DataFrame(X, columns=housing_num.columns, index=housing.index)
+    # Creating new columns
     housing_tr["rooms_per_household"] = (
         housing_tr["total_rooms"] / housing_tr["households"]
     )
@@ -42,7 +60,10 @@ def preprocess_data(housing):
         housing_tr["population"] / housing_tr["households"]
     )
 
+    # Just fetching the ocean_proximity column from housing data frame
     housing_cat = housing[["ocean_proximity"]]
+
+    # filling the values with true or false based on the value i.e: Inland, Nearbay
     housing_prepared = housing_tr.join(pd.get_dummies(housing_cat, drop_first=True))
 
     return housing_prepared

--- a/tests/test_nonstandardcode.py
+++ b/tests/test_nonstandardcode.py
@@ -9,6 +9,19 @@ from ml_package.data_ingestion import fetch_housing_data, load_housing_data
 from ml_package.data_preprocessing import preprocess_data, stratified_split
 from ml_package.training import train_linear_regression
 
+SAMPLE_TEST_DATA = {
+    "longitude": [-122.23, -122.24, -125.22],
+    "latitude": [37.2, 36.21, 37.9],
+    "house_median_age": [32, None, 12],
+    "total_rooms": [880, None, 167],
+    "total_bedrooms": [67, 21, 45],
+    "population": [332, 168, 250],
+    "households": [243, None, 222],
+    "median_income": [8.23, 9.22, 1.2],
+    "median_house_value": [425600, 452060, 404065],
+    "ocean_proximity": ["NEAR_BAY", "INLAND", "NEAR_BAY"],
+}
+
 
 def test_ispackage_installed():
     """
@@ -59,20 +72,9 @@ def test_stratified_split():
 def test_preprocess_data():
     """
     verifies that it returns the data without any NaN values
+    No NaN values after preprocessing
     """
-    test_data = {
-        "longitude": [-122.23, -122.24, -125.22],
-        "latitude": [37.2, 36.21, 37.9],
-        "house_median_age": [32, None, 12],
-        "total_rooms": [880, None, 167],
-        "total_bedrooms": [67, 21, 45],
-        "population": [332, 168, 250],
-        "households": [243, None, 222],
-        "median_income": [8.23, 9.22, 1.2],
-        "median_house_value": [425600, 452060, 404065],
-        "ocean_proximity": ["NEAR_BAY", "INLAND", "NEAR_BAY"],
-    }
-    test_data_df = pd.DataFrame(test_data)
+    test_data_df = pd.DataFrame(SAMPLE_TEST_DATA)
     processed_Data = preprocess_data(test_data_df)
     assert processed_Data.isna().sum().sum() == 0, "There are still missing values!"
 
@@ -88,24 +90,14 @@ def test_preprocess_data():
 
 def test_train_linear_regression():
     """
-    Verify the Linear Regression model training.
+    Tests Linear Regression training by verifying:
+    - No NaN values after preprocessing
+    - Model is successfully trained
+    - RMSE is a valid, non-negative number
     """
 
-    test_data = {
-        "longitude": [-122.23, -122.24, -125.22],
-        "latitude": [37.2, 36.21, 37.9],
-        "house_median_age": [32, None, 12],
-        "total_rooms": [880, None, 167],
-        "total_bedrooms": [67, 21, 45],
-        "population": [332, 168, 250],
-        "households": [243, None, 222],
-        "median_income": [8.23, 9.22, 1.2],
-        "median_house_value": [425600, 452060, 404065],  # Target column
-        "ocean_proximity": ["NEAR_BAY", "INLAND", "NEAR_BAY"],
-    }
-
     # Creating DataFrame
-    test_data_df = pd.DataFrame(test_data)
+    test_data_df = pd.DataFrame(SAMPLE_TEST_DATA)
 
     features = test_data_df.drop("median_house_value", axis=1)
     labels = test_data_df["median_house_value"].copy()


### PR DESCRIPTION
Closes #15 

- Workflow completed - Got Green build
-  Folder structure:
```
.
├── README.md
├── build
│   ├── bdist.linux-x[8](https://github.com/prsna123/mle-training/actions/runs/13118532356/job/36598707446#step:9:9)6_64
│   └── lib
│       └── ml_package
│           ├── __init__.py
│           ├── data_ingestion.py
│           ├── data_preprocessing.py
│           ├── learningcode.py
│           ├── main.py
│           ├── nonstandardcode.py
│           └── training.py
├── dist
│   ├── ml_package-0.1.0-py3-none-any.whl
│   └── ml_package-0.1.0.tar.gz
├── env.yml
├── settings.json
├── setup.py
├── src
│   ├── ml_package
│   │   ├── __init__.py
│   │   ├── data_ingestion.py
│   │   ├── data_preprocessing.py
│   │   ├── learningcode.py
│   │   ├── main.py
│   │   ├── nonstandardcode.py
│   │   └── training.py
│   └── ml_package.egg-info
│       ├── PKG-INFO
│       ├── SOURCES.txt
│       ├── dependency_links.txt
│       ├── requires.txt
│       └── top_level.txt
└── tests
    └── test_nonstandardcode.py
```
- Test Result:
```
collected 6 items

tests/test_nonstandardcode.py ......                                     [100%]

=============================== warnings summary ===============================
tests/test_nonstandardcode.py::test_fetch_housing_data
  /home/runner/.local/lib/python3.12/site-packages/ml_package/data_ingestion.py:18: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
    housing_tgz.extractall(path=housing_path)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================= 6 passed, 1 warning in 1.54s =========================
```
